### PR TITLE
fix: remove permission since it has error

### DIFF
--- a/.github/workflows/release-npm-registry-package.yml
+++ b/.github/workflows/release-npm-registry-package.yml
@@ -24,8 +24,6 @@ on:
 permissions:
   id-token: write
   contents: write
-  checks: write
-  statuses: write
 
 jobs:
   release:
@@ -89,5 +87,5 @@ jobs:
           if [ "${{ inputs.branch_name }}" == "dev" ]; then
             yarn auto canary --force
           else 
-            yarn auto shipit
+            yarn auto shipit --base-branch=main
           fi


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.2.1--canary.38.2828eeb.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @payconstruct/orbital-widget@4.2.1--canary.38.2828eeb.0
  # or 
  yarn add @payconstruct/orbital-widget@4.2.1--canary.38.2828eeb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
