### PR TITLE
fix: replace protected branch reviewer token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
       org_npmrc: ${{ secrets.ORG_NPMRC }}
       base_url_tst: ${{ secrets.BASE_URL_TST }}
       base_url: ${{ secrets.BASE_URL }}
+      protected_branch_reviewer_token: ${{ secrets.PROTECTED_BRANCH_REVIEWER_TOKEN }}
 
   upload_to_s3:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-npm-registry-package.yml
+++ b/.github/workflows/release-npm-registry-package.yml
@@ -20,6 +20,9 @@ on:
       org_npmrc:
         required: true
         description: .npmrc secret for GitHub Packages authentication
+      protected_branch_reviewer_token:
+        required: true
+        description: Protected branch reviewer token
 
 permissions:
   id-token: write
@@ -82,7 +85,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.deploy_token }}
           NODE_AUTH_TOKEN: ${{ secrets.deploy_token }}
-          PROTECTED_BRANCH_REVIEWER_TOKEN: ${{ secrets.deploy_token }}
+          PROTECTED_BRANCH_REVIEWER_TOKEN: ${{ secrets.protected_branch_reviewer_token }}
         run: |
           if [ "${{ inputs.branch_name }}" == "dev" ]; then
             yarn auto canary --force


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.2.1--canary.40.8083c00.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @payconstruct/orbital-widget@4.2.1--canary.40.8083c00.0
  # or 
  yarn add @payconstruct/orbital-widget@4.2.1--canary.40.8083c00.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
