### PR TITLE
fix: permission issue by setting git identity

### DIFF
--- a/.github/workflows/release-npm-registry-package.yml
+++ b/.github/workflows/release-npm-registry-package.yml
@@ -60,8 +60,8 @@ jobs:
 
       - name: Set Git Identity
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.email "github-bot@getorbital.com"
+          git config --global user.name "getorbital-bot"
           git fetch --unshallow --tags
 
       - name: Set env (optional)

--- a/.github/workflows/release-npm-registry-package.yml
+++ b/.github/workflows/release-npm-registry-package.yml
@@ -53,6 +53,17 @@ jobs:
           restore-keys: |
             yarn-deps-${{ hashFiles('yarn.lock') }}
 
+      - name: Use .npmrc
+        uses: bduff9/use-npmrc@v2.0.0
+        with:
+          dot-npmrc: ${{ secrets.org_npmrc }}
+
+      - name: Set Git Identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch --unshallow --tags
+
       - name: Set env (optional)
         id: setEnv
         run: |


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.3.7--canary.55.52aa77c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @payperform/widget@4.3.7--canary.55.52aa77c.0
  # or 
  yarn add @payperform/widget@4.3.7--canary.55.52aa77c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
