### PR TITLE
feat: package update should be in main branch only

### DIFF
--- a/.github/workflows/release-npm-registry-package.yml
+++ b/.github/workflows/release-npm-registry-package.yml
@@ -91,6 +91,7 @@ jobs:
           fi
 
       - name: Update example packages
+        if: ${{ inputs.branch_name == 'main' }}
         env:
           GITHUB_TOKEN: ${{ secrets.deploy_token }}
           NODE_AUTH_TOKEN: ${{ secrets.deploy_token }}
@@ -99,6 +100,7 @@ jobs:
           yarn run update-examples:all
 
       - name: Commit updated examples
+        if: ${{ inputs.branch_name == 'main' }}
         env:
           GITHUB_TOKEN: ${{ secrets.deploy_token }}
           NODE_AUTH_TOKEN: ${{ secrets.deploy_token }}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.3.9--canary.61.865c646.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @payperform/widget@4.3.9--canary.61.865c646.0
  # or 
  yarn add @payperform/widget@4.3.9--canary.61.865c646.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
