### PR TITLE
feat: use bot token which has push force permission

### DIFF
--- a/.github/workflows/release-npm-registry-package.yml
+++ b/.github/workflows/release-npm-registry-package.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Update example packages
         if: ${{ inputs.branch_name == 'main' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.deploy_token }}
+          GITHUB_TOKEN: ${{ secrets.protected_branch_reviewer_token }}
           NODE_AUTH_TOKEN: ${{ secrets.deploy_token }}
           NPM_TOKEN: ${{ secrets.npm_token }}
         run: |
@@ -102,7 +102,7 @@ jobs:
       - name: Commit updated examples
         if: ${{ inputs.branch_name == 'main' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.deploy_token }}
+          GITHUB_TOKEN: ${{ secrets.protected_branch_reviewer_token }}
           NODE_AUTH_TOKEN: ${{ secrets.deploy_token }}
           NPM_TOKEN: ${{ secrets.npm_token }}
         run: |


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.3.10--canary.63.23e0d13.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @payperform/widget@4.3.10--canary.63.23e0d13.0
  # or 
  yarn add @payperform/widget@4.3.10--canary.63.23e0d13.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
