### PR TITLE
feat: added example for server and change policy of iframe to allow top navigation

### DIFF
--- a/examples/server/index.js
+++ b/examples/server/index.js
@@ -1,0 +1,36 @@
+require('dotenv').config()
+const express = require('express')
+const axios = require('axios')
+const cors = require('cors')
+
+const app = express()
+// Enable CORS for all origins
+app.use(cors())
+app.use(express.json())
+
+app.post('/orbital-invoice-widget', async (req, res) => {
+  try {
+    const response = await axios.post(
+      process.env.API_URL || 'https://hpp.getorbital.io/invoice/widgets', // Use API URL from .env
+      req.body,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': process.env.API_KEY, // Use API key from .env
+        },
+      }
+    )
+
+    res.status(200).json(response.data)
+  } catch (error) {
+    res.status(500).json({
+      message: 'Error sending request',
+      error: error.response ? error.response.data : error.message,
+    })
+  }
+})
+
+const PORT = process.env.PORT || 3000
+app.listen(PORT, () => {
+  console.log(`Server is running on port ${PORT}`)
+})

--- a/examples/server/package.json
+++ b/examples/server/package.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "axios": "^1.7.7",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.21.0"
+  },
+  "scripts": {
+    "start": "node index.js"
+  }
+}

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -49,7 +49,7 @@ function renderWidget(element: HTMLElement) {
   const subDomain = signature?.includes('transaction-failed') ? signature : `/invoice/widgets?hppEncodedId=${signature}`
   const iframe = document.createElement('iframe')
   iframe.src = `${process.env.BASE_URL}${subDomain}`
-  iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin')
+  iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin allow-top-navigation')
   iframe.setAttribute('referrerpolicy', 'no-referrer')
   element.innerHTML = ''
   element.appendChild(iframe)


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>4.3.12--canary.76.91aaadb.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @payperform/widget@4.3.12--canary.76.91aaadb.0
  # or 
  yarn add @payperform/widget@4.3.12--canary.76.91aaadb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
