### PR TITLE
ci: add Dependabot automation and SonarQube workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+version: 2
+
+registries:
+  payconstruct-npm:
+    type: "npm-registry"
+    url: "https://npm.pkg.github.com"
+    token: "${{secrets.ORBITAL_GITHUB_BOT_TOKEN}}"
+    replaces-base: false
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "dev"
+    registries:
+      - payconstruct-npm
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(dev-deps)"
+      include: "scope"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [dev]
+
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: write
+  issues: write
+  security-events: read
+
+jobs:
+  auto-merge:
+    name: Dependabot Auto-Merge
+    if: github.actor == 'dependabot[bot]'
+    uses: PayConstruct/github-actions-workflows/.github/workflows/dependabot-auto-merge.yml@main
+    with:
+      branches: "dev"
+      critical-reviewers-teams: "crypto-team"
+      enable-auto-merge: true
+      enable-slack-notifications: true
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+      ORBITAL_GITHUB_BOT_TOKEN: ${{ secrets.ORBITAL_GITHUB_BOT_TOKEN }}

--- a/.github/workflows/dependabot-jira-ticket.yml
+++ b/.github/workflows/dependabot-jira-ticket.yml
@@ -1,0 +1,24 @@
+name: Dependabot Jira Ticket
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  jira-ticket:
+    name: Create Jira Ticket
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.merged == true
+    uses: PayConstruct/github-actions-workflows/.github/workflows/dependabot-jira-ticket.yml@main
+    with:
+      jira-project-key: "PMCR"
+      production-branch: "main"
+      jira-issue-type: "Ops"
+      jira-base-url: "https://getorbital.atlassian.net"
+    secrets:
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/dependabot-slack-notifications.yml
+++ b/.github/workflows/dependabot-slack-notifications.yml
@@ -1,0 +1,31 @@
+name: Dependabot Slack Notifications
+
+on:
+  pull_request:
+    types: [opened, closed, reopened]
+    branches: [dev]
+  pull_request_review:
+    types: [submitted]
+  workflow_run:
+    workflows: ["Dependabot Auto-Merge"]
+    types: [completed]
+  schedule:
+    - cron: "0 12 * * MON" # Every Monday at noon UTC
+
+jobs:
+  notify:
+    name: Dependabot Notifications
+    if: >
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_run' ||
+      github.actor == 'dependabot[bot]' ||
+      (github.event_name == 'pull_request_review' && github.event.pull_request.user.login == 'dependabot[bot]')
+    uses: PayConstruct/github-actions-workflows/.github/workflows/dependabot-slack-notifications.yml@main
+    with:
+      branches: "dev"
+      validation-workflows: "Dependabot Auto-Merge"
+      weekly-summary-schedule: "0 12 * * MON"
+      trigger-weekly-summary: ${{ github.event_name == 'schedule' }}
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,18 @@
+name: sonarqube
+
+on:
+  push:
+    branches:
+      - dev
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  sonarqube:
+    uses: PayConstruct/github-actions-workflows/.github/workflows/sonarqube.yml@main
+    with:
+      aws-region: eu-west-1
+      full-repo-name: ${{ github.repository }}
+    secrets: inherit

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,28 @@
+sonar.projectKey=ecomm-orbital-widget-js
+
+# Path is relative to the sonar-project.properties file. Defaults to .
+sonar.sources=src
+
+# Excluded src files and folders
+sonar.exclusions=**/*.test.ts,\
+                **/*.test.tsx,\
+                **/*.d.ts,\
+                **/examples/**,\
+                **/dist/**/*,\
+                **/lib/**/*,\
+                **/build/**/*,\
+                **/node_modules/**/*
+
+# Tests - Comma separated list of folders containing tests
+sonar.tests=tests
+sonar.test.inclusions=**/*.test.ts,**/*.test.tsx
+
+# Add coverage results
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+sonar.typescript.tsconfigPath=tsconfig.json
+
+# Dependency Check configuration
+sonar.dependencyCheck.jsonReportPath=reports/dependency-check-report.json
+sonar.dependencyCheck.htmlReportPath=reports/dependency-check-report.html
+sonar.dependencyCheck.format=JSON


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` for npm + github-actions updates, targeting `dev`, authenticated to the org GitHub Packages registry, with prod/dev grouping to reduce PR noise.
- Add reusable-workflow callers for the Dependabot lifecycle: auto-merge (with severity classification + `crypto-team` review on critical/high), Jira ticket creation in `PMCR` (issue type `Ops`, deploy target `main`), and Slack notifications.
- Add a SonarQube caller workflow (runs on push to `dev`) plus `sonar-project.properties` tailored to this repo's `src`/`tests` layout and `coverage/lcov.info`.

## Flow
Dependabot opens PRs against `dev` → auto-merge classifies/merges safe & security updates → on merge a `PMCR` `Ops` ticket is created to test and deploy to `main` → Slack posts PR/merge/failure events and a weekly summary.

## Required secrets
- Dependabot store: `ORBITAL_GITHUB_BOT_TOKEN`
- Actions store: `JIRA_API_TOKEN`, `JIRA_USER_EMAIL`, `SLACK_BOT_TOKEN`, `SLACK_CHANNEL_ID`
- SonarQube (via `secrets: inherit`): `SONAR_TOKEN`, `OSSINDEX_USERNAME`, `OSSINDEX_PASSWORD`, `TECH_AWS_ACCOUNT_IAM_ROLE`

Note: this repo is public, so org secrets scoped to private repos must be added at repo level or have this repo added to their selected-repos list.

## Test plan
- [ ] Confirm required secrets are resolvable in this repo
- [ ] Enable "Allow auto-merge" in repo settings
- [ ] Verify the SonarQube `projectKey` (`ecomm-orbital-widget-js`) exists on the Sonar server
- [ ] Observe the first Dependabot PRs against `dev` and the auto-merge/Jira flow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Auto-merge and bot tokens can merge dependency PRs without human review for non-critical updates; misconfigured secrets or overly permissive auto-merge could introduce bad deps, but no runtime app code changes.
> 
> **Overview**
> Introduces **Dependabot** and **SonarQube** automation for this repo, all targeting **`dev`** as the integration branch.
> 
> **Dependabot** (`.github/dependabot.yml`) opens weekly PRs for **npm** (via GitHub Packages registry auth) and **github-actions**, with grouped minor/patch updates and conventional commit prefixes. Three workflows wire the lifecycle: **auto-merge** for `dependabot[bot]` PRs (with `crypto-team` review on critical/high), **Jira** `PMCR` `Ops` tickets when a Dependabot PR merges (deploy path to `main`), and **Slack** notifications plus a Monday weekly summary.
> 
> **SonarQube** runs on push to `dev` via a reusable org workflow; **`sonar-project.properties`** sets `ecomm-orbital-widget-js`, scans `src`/`tests`, and points at `coverage/lcov.info` and dependency-check reports.
> 
> No application source changes—only CI/config and required repo/org secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cee6125d809aba8175bd1dbce96f436bf89778a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->